### PR TITLE
Docs: Document timestampMs API schema fields

### DIFF
--- a/specification/common/transactions/BaseTransaction.yaml
+++ b/specification/common/transactions/BaseTransaction.yaml
@@ -32,6 +32,11 @@ properties:
     type: number
   timestamp:
     type: number
+    description: Transaction time specified by the sender, measured in seconds since the ADAMANT epoch.
+  timestampMs:
+    type: number
+    nullable: true
+    description: Optional transaction time specified by the sender, measured in milliseconds since the ADAMANT epoch. Returned when a node has stored it; for blockchain consensus-sensitive data this works after the `spaceship` activation. When present, it belongs to the same second as `timestamp`, so clients should prefer it for timestamp ordering and fall back to `timestamp * 1000` when it is absent.
   senderPublicKey:
     type: string
   senderId:

--- a/specification/common/transactions/QueuedTransaction.yaml
+++ b/specification/common/transactions/QueuedTransaction.yaml
@@ -35,6 +35,11 @@ properties:
   timestamp:
     type: integer
     example: 63394407
+  timestampMs:
+    type: integer
+    nullable: true
+    example: 63394407123
+    description: Optional transaction time measured in milliseconds since the ADAMANT epoch. Available for transactions that include it; for consensus-sensitive blockchain storage it works after the `spaceship` activation. When present, it belongs to the same second as `timestamp`.
   signature:
     type: string
     example: 7f4f5d240fc66da1cbdb3fe291d6fcec006848236355aebe346fcd1e3ba500caeac1ed0af6f3d7f912a889a1bbedc1d7bab17b6ebd36386b81df78189ddf7c07

--- a/specification/common/transactions/register/RegisterTransactionBase.yaml
+++ b/specification/common/transactions/register/RegisterTransactionBase.yaml
@@ -18,6 +18,10 @@ properties:
     type: string
   timestamp:
     type: integer
+    description: Transaction time measured in seconds since the ADAMANT epoch.
+  timestampMs:
+    type: integer
+    description: Optional transaction time measured in milliseconds since the ADAMANT epoch. Supported by upgraded nodes and stored in consensus-sensitive transaction data after the `spaceship` activation. If provided, clients should derive `timestamp` from the same value using `Math.floor(timestampMs / 1000)`; `round` or `ceil` can create an invalid timestamp pair.
 example:
   type: 0
   amount: 0
@@ -25,3 +29,4 @@ example:
   senderPublicKey: 8cd9631f9f634a361ea3b85cbd0df882633e39e7d26d7bc615bbcf75e41524ef
   signature: b3982d603be8f0246fa663e9f012bf28b198cd28f82473db1eb4a342d890f7a2a2c1845db8d256bb5bce1e64a9425822a91e10bf960a2e0b55e20b4841e4ae0b
   timestamp: 63228852
+  timestampMs: 63228852123

--- a/specification/nodes/GetNodeStatus/GetNodeStatusResponseDto.yaml
+++ b/specification/nodes/GetNodeStatus/GetNodeStatusResponseDto.yaml
@@ -1,6 +1,8 @@
 required:
   - success
   - nodeTimestamp
+  - nodeTimestampMs
+  - unixTimestampMs
   - loader
   - network
   - version
@@ -12,6 +14,15 @@ properties:
   nodeTimestamp:
     type: number
     example: 58052984
+    description: Current node time measured in seconds since the ADAMANT epoch.
+  nodeTimestampMs:
+    type: number
+    example: 58052984123
+    description: Current node time measured in milliseconds since the ADAMANT epoch. This is node clock metadata and is not consensus data.
+  unixTimestampMs:
+    type: number
+    example: 1562424584123
+    description: Current node time measured in Unix milliseconds. This is node clock metadata and is not consensus data.
   loader:
     required:
       - loaded


### PR DESCRIPTION
## Description

Documents the `timestampMs` transaction field and node clock millisecond fields in the OpenAPI schema.

This PR marks `timestampMs` as ADAMANT epoch milliseconds, optional in responses, and stored for consensus-sensitive blockchain data after the `spaceship` activation. It also documents that clients should derive `timestamp` with `Math.floor(timestampMs / 1000)` when submitting transactions with `timestampMs`.

## Related

- Adamant-im/adamant#209
- Adamant-im/adamant#210
- Adamant-im/AIPs#62

## How to test

```bash
npm ci
npm run bundle
npx prettier --write specification/common/transactions/BaseTransaction.yaml specification/common/transactions/QueuedTransaction.yaml specification/common/transactions/register/RegisterTransactionBase.yaml specification/nodes/GetNodeStatus/GetNodeStatusResponseDto.yaml
git diff --check
```

Result: bundle completed successfully with pre-existing Redocly duplicate-name warnings for existing refs.