### PR TITLE
Enhancement: Add testnet nodes and live health-check to Servers dropdown

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -43,6 +43,7 @@ function operationSearchPlugin() {
 
 const app = express();
 const swaggerDocument = require('./dist/schema.json');
+const { version: packageVersion } = require('./package.json');
 const swaggerUiOptions = {
   customSiteTitle: 'ADAMANT Node API',
   swaggerOptions: {
@@ -71,6 +72,157 @@ const swaggerUiOptions = {
 
       observer.observe(document.body, { childList: true, subtree: true });
     });
+
+    (function () {
+      var TIMEOUT_MS = 10000;
+      var PACKAGE_VERSION = '${packageVersion}';
+
+      function originalLabel(option) {
+        if (!option.dataset.originalLabel) {
+          option.dataset.originalLabel = option.textContent;
+        }
+        return option.dataset.originalLabel;
+      }
+
+      function parseOption(option) {
+        var text = originalLabel(option);
+        var sep = text.indexOf(' - ');
+        var url = sep >= 0 ? text.slice(0, sep) : text;
+        var description = sep >= 0 ? text.slice(sep + 3) : '';
+        return { url: url, description: description };
+      }
+
+      function statusUrl(apiUrl) {
+        return apiUrl.replace(/\\/+$/, '') + '/node/status';
+      }
+
+      function displayUrl(apiUrl) {
+        return apiUrl.replace(/\\/api\\/?$/, '');
+      }
+
+      function buildLabel(result) {
+        var label = result.displayUrl;
+        if (result.description) label += ' — ' + result.description;
+        label += result.version
+          ? ', API v' + result.version
+          : ' (Ping failed)';
+        return label;
+      }
+
+      function fetchVersion(apiUrl) {
+        var controller = new AbortController();
+        var timer = setTimeout(function () {
+          controller.abort();
+        }, TIMEOUT_MS);
+
+        return fetch(statusUrl(apiUrl), { signal: controller.signal })
+          .then(function (response) {
+            if (!response.ok) throw new Error('HTTP ' + response.status);
+            return response.json();
+          })
+          .then(function (data) {
+            return data && data.version && data.version.version;
+          })
+          .finally(function () {
+            clearTimeout(timer);
+          });
+      }
+
+      function compareVersions(a, b) {
+        var pa = String(a).split('.');
+        var pb = String(b).split('.');
+        var len = Math.max(pa.length, pb.length);
+        for (var i = 0; i < len; i++) {
+          var na = parseInt(pa[i], 10) || 0;
+          var nb = parseInt(pb[i], 10) || 0;
+          if (na !== nb) return na - nb;
+        }
+        return 0;
+      }
+
+      function setServerValue(select, value) {
+        var setter = Object.getOwnPropertyDescriptor(
+          window.HTMLSelectElement.prototype,
+          'value'
+        ).set;
+        setter.call(select, value);
+        select.dispatchEvent(new Event('change', { bubbles: true }));
+      }
+
+      function selectBest(select, results) {
+        var responding = results.filter(function (r) {
+          return r.version && /^Mainnet/.test(r.description);
+        });
+        if (!responding.length) return;
+
+        var chosen = responding.find(function (r) {
+          return r.version === PACKAGE_VERSION;
+        });
+
+        if (!chosen) {
+          var highest = responding.reduce(function (best, r) {
+            return compareVersions(r.version, best.version) > 0 ? r : best;
+          }).version;
+          chosen = responding.find(function (r) {
+            return r.version === highest;
+          });
+        }
+
+        if (chosen) setServerValue(select, chosen.url);
+      }
+
+      function runHealthCheck(select) {
+        var results = Array.prototype.map.call(
+          select.options,
+          function (option) {
+            var parsed = parseOption(option);
+            return {
+              option: option,
+              url: option.value || parsed.url,
+              displayUrl: displayUrl(option.value || parsed.url),
+              description: parsed.description,
+              version: null,
+            };
+          }
+        );
+
+        var checks = results.map(function (result) {
+          return fetchVersion(result.url)
+            .then(function (version) {
+              result.version = version || null;
+            })
+            .catch(function () {
+              result.version = null;
+            })
+            .finally(function () {
+              result.option.text = buildLabel(result);
+            });
+        });
+
+        return Promise.allSettled(checks).then(function () {
+          selectBest(select, results);
+        });
+      }
+
+      function checkServerSelect() {
+        var select = document.querySelector('.servers select');
+        if (!select || select.__healthChecked) return !!select;
+
+        select.__healthChecked = true;
+        runHealthCheck(select);
+        return true;
+      }
+
+      window.addEventListener('load', function () {
+        if (checkServerSelect()) return;
+
+        var observer = new MutationObserver(function () {
+          if (checkServerSelect()) observer.disconnect();
+        });
+
+        observer.observe(document.body, { childList: true, subtree: true });
+      });
+    })();
   `,
 };
 

--- a/specification/openapi.yaml
+++ b/specification/openapi.yaml
@@ -29,6 +29,10 @@ servers:
     description: Mainnet Endless
   - url: https://ahead.adamant.im/api
     description: Mainnet Dev
+  - url: https://testnode1.adamant.im/api
+    description: Testnet 1
+  - url: https://testnode3.adm.im/api
+    description: Testnet 3
 
 components:
   schemas:


### PR DESCRIPTION
Closes #34

## Summary

- Add testnet nodes (`testnode1.adamant.im`, `testnode3.adm.im`) to `servers` list in `specification/openapi.yaml`
- Inject live health-check logic into Swagger UI via `customJsStr` in `app.ts`

## Changes

### `specification/openapi.yaml`

Added two testnet server entries after the existing mainnet nodes:

```yaml
- url: https://testnode1.adamant.im/api
  description: Testnet 1
- url: https://testnode3.adm.im/api
  description: Testnet 3
```

### `app.ts`

On page load (once per page view), fires parallel `GET /api/node/status` requests to every server in the dropdown with a 10 s per-node timeout. Labels are updated as responses arrive:

| Case | Displayed label |
|------|----------------|
| Node responded | `https://lake.adamant.im — Mainnet Lake, API v0.7.0` |
| Timeout / error | `https://lake.adamant.im — Mainnet Lake (Ping failed)` |

After all checks settle, auto-selects the best available mainnet node by priority:

1. First responding mainnet node whose `version.version` matches `package.json` version
2. Otherwise first responding mainnet node with the highest `version.version`
3. If no mainnet node responds — Swagger UI default is left unchanged

"Mainnet node" = server whose `description` starts with `Mainnet`.

## Downstream consumer impact

No schema contract changes — only `servers` entries and UI behaviour are affected. `adamant-api-jsclient` type generation is not impacted.
