### PR TITLE
Release: Fix deployed Swagger UI rendering (v0.10.0 hotfix)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,8 @@ Formatting is handled by Prettier. It runs automatically on pre-commit (husky + 
 
 Pushing to `master` triggers the GitHub Actions workflow (`.github/workflows/github-pages.yaml`) which bundles and deploys to GitHub Pages → <https://schema.adamant.im>.
 
+**GitHub Pages does NOT run `app.ts`.** The workflow only runs `npm run bundle` and uploads the `dist/` directory. The deployed Swagger UI is the static `dist/index.html` (tracked in git), which loads `swagger-ui-dist` from a CDN and configures `SwaggerUIBundle` inline. `app.ts` is only the local `npm run start` server. So any Swagger UI change made in `app.ts` (options, plugins, custom JS) must be mirrored in `dist/index.html`, or it will work locally but not on the deployed site. Also keep `dist/index.html`'s pinned `swagger-ui-dist` version compatible with the spec's OpenAPI version (e.g. OpenAPI 3.2 needs swagger-ui-dist ≥ 5.17).
+
 Work in `dev` and open PRs targeting `dev`. Merges to `master` are release actions.
 
 ## Issue, Label, and PR Conventions

--- a/dist/index.html
+++ b/dist/index.html
@@ -4,20 +4,20 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="SwaggerUI" />
-    <title>ADAMANT OpenAPI Specification</title>
+    <title>ADAMANT Node API</title>
     <link
       rel="stylesheet"
-      href="https://unpkg.com/swagger-ui-dist@5.3.1/swagger-ui.css"
+      href="https://unpkg.com/swagger-ui-dist@5.32.6/swagger-ui.css"
     />
   </head>
   <body>
     <div id="swagger-ui"></div>
     <script
-      src="https://unpkg.com/swagger-ui-dist@5.3.1/swagger-ui-bundle.js"
+      src="https://unpkg.com/swagger-ui-dist@5.32.6/swagger-ui-bundle.js"
       crossorigin
     ></script>
     <script
-      src="https://unpkg.com/swagger-ui-dist@5.3.1/swagger-ui-standalone-preset.js"
+      src="https://unpkg.com/swagger-ui-dist@5.32.6/swagger-ui-standalone-preset.js"
       crossorigin
     ></script>
     <script>

--- a/dist/index.html
+++ b/dist/index.html
@@ -3,12 +3,17 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="description" content="SwaggerUI" />
+    <meta name="description" content="ADAMANT Node API" />
     <title>ADAMANT Node API</title>
     <link
       rel="stylesheet"
       href="https://unpkg.com/swagger-ui-dist@5.32.6/swagger-ui.css"
     />
+    <style>
+      .swagger-ui .topbar .download-url-wrapper {
+        display: none;
+      }
+    </style>
   </head>
   <body>
     <div id="swagger-ui"></div>
@@ -21,12 +26,247 @@
       crossorigin
     ></script>
     <script>
+      // Keep this configuration in sync with app.ts (the local `npm run start`
+      // server), so the deployed Swagger UI behaves identically.
+      function operationSearchPlugin() {
+        return {
+          fn: {
+            opsFilter(taggedOperations, filter) {
+              const query = String(filter).trim().toLowerCase();
+
+              if (!query) {
+                return taggedOperations;
+              }
+
+              return taggedOperations
+                .map((tagData, tagName) => {
+                  if (String(tagName).toLowerCase().includes(query)) {
+                    return tagData;
+                  }
+
+                  const operations = tagData
+                    .get('operations')
+                    .filter((item) => {
+                      const operation = item.get('operation');
+                      const searchableValues = [
+                        item.get('path'),
+                        item.get('method'),
+                        operation.get('operationId'),
+                        operation.get('summary'),
+                      ];
+
+                      return searchableValues.some((value) =>
+                        String(value ?? '')
+                          .toLowerCase()
+                          .includes(query)
+                      );
+                    });
+
+                  return tagData.set('operations', operations);
+                })
+                .filter((tagData) => !tagData.get('operations').isEmpty());
+            },
+          },
+        };
+      }
+
       window.onload = () => {
         window.ui = SwaggerUIBundle({
-          url: "schema.json",
-          dom_id: "#swagger-ui",
+          url: 'schema.json',
+          dom_id: '#swagger-ui',
+          deepLinking: true,
+          persistAuthorization: true,
+          displayRequestDuration: true,
+          filter: true,
+          presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
+          plugins: [operationSearchPlugin],
+          layout: 'StandaloneLayout',
         });
       };
+    </script>
+    <script>
+      window.addEventListener('load', function () {
+        function updateSearchPlaceholder() {
+          const input = document.querySelector('.operation-filter-input');
+
+          if (!input) return false;
+
+          input.placeholder = 'Search operations';
+          return true;
+        }
+
+        if (updateSearchPlaceholder()) return;
+
+        const observer = new MutationObserver(function () {
+          if (updateSearchPlaceholder()) observer.disconnect();
+        });
+
+        observer.observe(document.body, { childList: true, subtree: true });
+      });
+
+      (function () {
+        var TIMEOUT_MS = 5000;
+
+        // Derived from the bundled spec (info.version), which tracks the
+        // package/node version — avoids hardcoding the release version here.
+        function packageVersion() {
+          try {
+            return (
+              window.ui.specSelectors.specJson().get('info').get('version') ||
+              ''
+            );
+          } catch (e) {
+            return '';
+          }
+        }
+
+        function originalLabel(option) {
+          if (!option.dataset.originalLabel) {
+            option.dataset.originalLabel = option.textContent;
+          }
+          return option.dataset.originalLabel;
+        }
+
+        function parseOption(option) {
+          var text = originalLabel(option);
+          var sep = text.indexOf(' - ');
+          var url = sep >= 0 ? text.slice(0, sep) : text;
+          var description = sep >= 0 ? text.slice(sep + 3) : '';
+          return { url: url, description: description };
+        }
+
+        function statusUrl(apiUrl) {
+          return apiUrl.replace(/\/+$/, '') + '/node/status';
+        }
+
+        function displayUrl(apiUrl) {
+          return apiUrl.replace(/\/api\/?$/, '');
+        }
+
+        function buildLabel(result) {
+          var label = result.displayUrl;
+          if (result.description) label += ' — ' + result.description;
+          label += result.version
+            ? ', API v' + result.version
+            : ' (Ping failed)';
+          return label;
+        }
+
+        function fetchVersion(apiUrl) {
+          var controller = new AbortController();
+          var timer = setTimeout(function () {
+            controller.abort();
+          }, TIMEOUT_MS);
+
+          return fetch(statusUrl(apiUrl), { signal: controller.signal })
+            .then(function (response) {
+              if (!response.ok) throw new Error('HTTP ' + response.status);
+              return response.json();
+            })
+            .then(function (data) {
+              return data && data.version && data.version.version;
+            })
+            .finally(function () {
+              clearTimeout(timer);
+            });
+        }
+
+        function compareVersions(a, b) {
+          var pa = String(a).split('.');
+          var pb = String(b).split('.');
+          var len = Math.max(pa.length, pb.length);
+          for (var i = 0; i < len; i++) {
+            var na = parseInt(pa[i], 10) || 0;
+            var nb = parseInt(pb[i], 10) || 0;
+            if (na !== nb) return na - nb;
+          }
+          return 0;
+        }
+
+        function setServerValue(select, value) {
+          var setter = Object.getOwnPropertyDescriptor(
+            window.HTMLSelectElement.prototype,
+            'value'
+          ).set;
+          setter.call(select, value);
+          select.dispatchEvent(new Event('change', { bubbles: true }));
+        }
+
+        function selectBest(select, results) {
+          var PACKAGE_VERSION = packageVersion();
+          var responding = results.filter(function (r) {
+            return r.version && /^Mainnet/.test(r.description);
+          });
+          if (!responding.length) return;
+
+          var chosen = responding.find(function (r) {
+            return r.version === PACKAGE_VERSION;
+          });
+
+          if (!chosen) {
+            var highest = responding.reduce(function (best, r) {
+              return compareVersions(r.version, best.version) > 0 ? r : best;
+            }).version;
+            chosen = responding.find(function (r) {
+              return r.version === highest;
+            });
+          }
+
+          if (chosen) setServerValue(select, chosen.url);
+        }
+
+        function runHealthCheck(select) {
+          var results = Array.prototype.map.call(
+            select.options,
+            function (option) {
+              var parsed = parseOption(option);
+              return {
+                option: option,
+                url: option.value || parsed.url,
+                displayUrl: displayUrl(option.value || parsed.url),
+                description: parsed.description,
+                version: null,
+              };
+            }
+          );
+
+          var checks = results.map(function (result) {
+            return fetchVersion(result.url)
+              .then(function (version) {
+                result.version = version || null;
+              })
+              .catch(function () {
+                result.version = null;
+              })
+              .finally(function () {
+                result.option.text = buildLabel(result);
+              });
+          });
+
+          return Promise.allSettled(checks).then(function () {
+            selectBest(select, results);
+          });
+        }
+
+        function checkServerSelect() {
+          var select = document.querySelector('.servers select');
+          if (!select || select.__healthChecked) return !!select;
+
+          select.__healthChecked = true;
+          runHealthCheck(select);
+          return true;
+        }
+
+        window.addEventListener('load', function () {
+          if (checkServerSelect()) return;
+
+          var observer = new MutationObserver(function () {
+            if (checkServerSelect()) observer.disconnect();
+          });
+
+          observer.observe(document.body, { childList: true, subtree: true });
+        });
+      })();
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Description

Hotfix release on top of v0.10.0. After the v0.10.0 release, [schema.adamant.im](https://schema.adamant.im) failed to render with:

> Unable to render this definition. The provided definition does not specify a valid version field… Supported version fields are `swagger: "2.0"` and those that match `openapi: 3.x.y`.

Merging this `dev → master` triggers the GitHub Pages redeploy.

### Root cause

GitHub Pages does not run `app.ts` — it only runs `npm run bundle` and serves the static `dist/index.html`. That file pinned `swagger-ui-dist@5.3.1` (too old for OpenAPI 3.2) and called `SwaggerUIBundle` with just `url` + `dom_id`, so it also lacked every customization the local `npm run start` server applies.

### Changes (diff `master…dev`)

**`dist/index.html`** — brought to full parity with `app.ts`:
- Bumped `swagger-ui-dist` `5.3.1 → 5.32.6` (renders OpenAPI 3.2.0; matches the version `swagger-ui-express` bundles locally).
- Ported `operationSearchPlugin` (search by tag, path, method, `operationId`, summary) — search was previously disabled on the deployed page.
- Enabled `filter`, `deepLinking`, `persistAuthorization`, `displayRequestDuration`.
- `StandaloneLayout` + `apis`/standalone presets, `.topbar .download-url-wrapper` hidden (swagger-ui-express defaults).
- `"Search operations"` placeholder tweak.
- Node `/node/status` health check that labels each server with its live API version and auto-selects the best responding mainnet node (release version read from the bundled spec, not hardcoded).
- Title → `ADAMANT Node API`.

**`AGENTS.md`** — documented that GitHub Pages serves the static `dist/index.html` (not `app.ts`), so Swagger UI changes must be mirrored there and the pinned `swagger-ui-dist` must support the spec's OpenAPI version.

## Related issue

Closes #38

## Breaking changes

None.

## How to test

After merge, open https://schema.adamant.im and confirm:
- the spec renders (no "valid version field" error),
- the operation search box filters by path/method/summary/tag,
- server dropdown entries show their live API version and a mainnet node is auto-selected.

## Checklist

- [x] Code is formatted
- [x] Documentation updated (if needed)
- [x] Changes tested in all relevant environments
