### PR TITLE
Bug: Align response DTO fields with node responses

### DIFF
--- a/specification/blocks/BlockInfoDto.yaml
+++ b/specification/blocks/BlockInfoDto.yaml
@@ -10,6 +10,7 @@ required:
   - reward
   - payloadLength
   - payloadHash
+  - generatorPublicKey
   - generatorId
   - blockSignature
   - confirmations
@@ -38,6 +39,8 @@ properties:
   payloadLength:
     type: number
   payloadHash:
+    type: string
+  generatorPublicKey:
     type: string
   generatorId:
     type: string

--- a/specification/delegates/DelegateDto.yaml
+++ b/specification/delegates/DelegateDto.yaml
@@ -26,7 +26,7 @@ properties:
   votesWeight:
     type: string
     description: Vote weight (Fair Delegate System)
-  producedlocks:
+  producedblocks:
     type: integer
     description: Count of produced blocks
   missedblocks:


### PR DESCRIPTION
## Objective
Align the OpenAPI response DTOs with ADAMANT Node response fields documented in #42.

## Changes
- Renamed `DelegateDto.properties.producedlocks` to `producedblocks` to match the required field, examples, and node responses.
- Added `BlockInfoDto.generatorPublicKey` to `required` and `properties` to match block responses.

## Verification
- [x] `npm run bundle`
- [x] `npx prettier --check specification/delegates/DelegateDto.yaml specification/blocks/BlockInfoDto.yaml`
- [x] `npx tsc --noEmit`
- [x] `git diff --check`

## Related Issues
Closes #42

## Consumer Impact
Generated clients will expose the canonical `producedblocks` field and include `generatorPublicKey` on block DTOs.