### PR TITLE
Fix: Align blocks API schema with node behavior

### DIFF
--- a/specification/blocks/GetBlockInfo/GetBlockInfoParams.yaml
+++ b/specification/blocks/GetBlockInfo/GetBlockInfoParams.yaml
@@ -3,4 +3,8 @@
   description: Block ID
   required: true
   schema:
-    type: integer
+    type: string
+    minLength: 1
+    maxLength: 20
+    pattern: '^[0-9]+$'
+    example: '11114690216332606721'

--- a/specification/blocks/GetBlocks/GetBlocksQueryParams.yaml
+++ b/specification/blocks/GetBlocks/GetBlocksQueryParams.yaml
@@ -1,6 +1,6 @@
 - name: limit
   in: query
-  description: How much blocks to get, integer. Default is `100`.
+  description: Number of blocks to retrieve. Default is `100`.
   required: false
   schema:
     type: integer
@@ -10,21 +10,81 @@
     default: 100
 - name: offset
   in: query
-  description: Height offset value for results. Default is `0`.
+  description: Number of rows to skip after applying the requested order. Default is `0`.
   required: false
   schema:
     type: integer
     format: int32
+    minimum: 0
     default: 0
-- name: generatorPublicKey
+- name: orderBy
   in: query
-  description: Delegate's public key of ADAMANT address who generated the block
+  description: >-
+    Sort expression in `field:direction` form. Supported fields are `id`, `timestamp`, `height`,
+    `previousBlock`, `totalAmount`, `totalFee`, `reward`, `numberOfTransactions`, and
+    `generatorPublicKey`. Supported directions are `asc` and `desc`.
   required: false
   schema:
     type: string
-- name: height
+    default: height:desc
+    example: timestamp:asc
+- name: generatorPublicKey
   in: query
-  description: Get block of specific node's height
+  description: Public key of the delegate who generated the block.
   required: false
   schema:
-    type: number
+    type: string
+    minLength: 64
+    maxLength: 64
+    pattern: '^[0-9a-fA-F]{64}$'
+    example: 134a5de88c7da1ec71e75b5250d24168c6c6e3965ff16bd71497bd015d40ea6a
+- name: numberOfTransactions
+  in: query
+  description: Exact number of transactions in the block.
+  required: false
+  schema:
+    type: integer
+    minimum: 0
+- name: previousBlock
+  in: query
+  description: ID of the preceding block.
+  required: false
+  schema:
+    type: string
+    minLength: 1
+    maxLength: 20
+    pattern: '^[0-9]+$'
+    example: '11483763337863654141'
+- name: height
+  in: query
+  description: Exact block height.
+  required: false
+  schema:
+    type: integer
+    minimum: 1
+- name: totalAmount
+  in: query
+  description: Exact total amount transferred by the block's transactions, in 1/10^8 ADM.
+  required: false
+  schema:
+    type: integer
+    format: int64
+    minimum: 0
+    maximum: 9800000000000000
+- name: totalFee
+  in: query
+  description: Exact total transaction fee in the block, in 1/10^8 ADM.
+  required: false
+  schema:
+    type: integer
+    format: int64
+    minimum: 0
+    maximum: 9800000000000000
+- name: reward
+  in: query
+  description: Exact forging reward for the block, in 1/10^8 ADM.
+  required: false
+  schema:
+    type: integer
+    format: int64
+    minimum: 0


### PR DESCRIPTION
## Description

Align the OpenAPI blocks definitions with the current ADAMANT Node `dev` behavior.

`GET /blocks` now exposes every supported filter together with `orderBy`, accurate pagination semantics, node-equivalent numeric bounds, and string constraints for generator keys and block IDs. The `/blocks/get` query parameter now represents the block ID as a decimal string instead of an unsafe JavaScript integer.

The response DTO is intentionally unchanged because it already matches the node and does not include `timestampMs`.

## Related issue

Closes #45

## External links (optional)

- Node performance bug: https://github.com/Adamant-im/adamant/issues/258
- Node implementation: https://github.com/Adamant-im/adamant/pull/263
- Documentation issue: https://github.com/Adamant-im/docs/issues/32
- Documentation PR: https://github.com/Adamant-im/docs/pull/33

## Screenshots or videos (optional)

Not applicable. The affected operations were verified in the local Swagger UI.

## Breaking changes

There is no runtime API change.

Generated clients may change the `/blocks/get` `id` query parameter from a numeric type to a string. Consumers should pass decimal block IDs as strings, which matches the existing node request schema and avoids precision loss for unsigned 64-bit IDs.

## How to test

```sh
npx prettier --check specification/blocks/GetBlocks/GetBlocksQueryParams.yaml specification/blocks/GetBlockInfo/GetBlockInfoParams.yaml
npm run bundle
npm run start
```

In the local Swagger UI:

1. Expand `GET /blocks` and verify all filters and `orderBy` are displayed with their constraints.
2. Expand `GET /blocks/get` and verify the block ID is rendered as a string with a 20-digit example.

## Notes for reviewers

- The source YAML files are the only tracked files changed; `dist/schema.json` is generated during validation.
- Query parameter names and constraints were checked against ADAMANT Node `schema/blocks.js`.
- Allowed sort fields were checked against ADAMANT Node `sql/blocks.js`.
- Downstream `adamant-api-jsclient` types may need regeneration after merge because of the corrected block ID query type and newly exposed optional query parameters.

## Checklist

- [x] Code is formatted
- [x] Tests added/updated (if needed)
- [x] Documentation updated (if needed)
- [x] Changes tested in all relevant environments
