### PR TITLE
Feat: Define client WebSocket subscription and event schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > OpenAPI 3.2 specification for the ADAMANT Node API, with interactive Swagger UI.
 
-[ADAMANT](https://adamant.im) is a decentralized messenger built on its own blockchain. This specification defines the RESTful interface for interacting with an ADAMANT Node — covering accounts, transactions, chats, delegates, blocks, and more.
+[ADAMANT](https://adamant.im) is a decentralized messenger built on its own blockchain. This specification defines the RESTful interface for interacting with an ADAMANT Node — covering accounts, transactions, chats, delegates, blocks, and more. Reusable client WebSocket subscription and event payload contracts are included under the top-level `x-client-websocket` extension.
 
 **Live schema:** [schema.adamant.im](https://schema.adamant.im)
 
@@ -26,11 +26,11 @@ npm run start:watch
 
 ## Commands
 
-| Command | Description |
-|---|---|
-| `npm run bundle` | Bundle `specification/` into `dist/schema.json` |
-| `npm run start` | Bundle and start Swagger UI at http://localhost:3000 |
-| `npm run start:watch` | Watch `specification/` for changes and auto-rebuild |
+| Command               | Description                                          |
+| --------------------- | ---------------------------------------------------- |
+| `npm run bundle`      | Bundle `specification/` into `dist/schema.json`      |
+| `npm run start`       | Bundle and start Swagger UI at http://localhost:3000 |
+| `npm run start:watch` | Watch `specification/` for changes and auto-rebuild  |
 
 ## Example: generate TypeScript types
 

--- a/specification/openapi.yaml
+++ b/specification/openapi.yaml
@@ -89,7 +89,7 @@ components:
     ClientWebSocketBlockSubscription:
       $ref: 'websocket/BlockSubscription.yaml'
     ClientWebSocketNewTransaction:
-      $ref: 'common/transactions/AnyTransaction.yaml'
+      $ref: 'common/transactions/UnconfirmedTransaction.yaml'
     ClientWebSocketBalanceChange:
       $ref: 'websocket/BalanceChangeEvent.yaml'
     ClientWebSocketNewBlock:

--- a/specification/openapi.yaml
+++ b/specification/openapi.yaml
@@ -34,8 +34,67 @@ servers:
   - url: https://testnode3.adm.im/api
     description: Testnet 3
 
+x-client-websocket:
+  protocol: Socket.IO
+  description: >-
+    Opt-in live events exposed by the node's client WebSocket server. Discover availability and
+    the client port through GET /node/status. Subscriptions are scoped to one socket and must be
+    restored after reconnecting.
+  clientEvents:
+    address:
+      description: Adds addresses used by transaction filters and balance subscriptions.
+      payload:
+        $ref: '#/components/schemas/ClientWebSocketAddressSubscription'
+    types:
+      description: Adds transaction types used by newTrans filtering.
+      payload:
+        $ref: '#/components/schemas/ClientWebSocketTransactionTypeSubscription'
+    assetChatTypes:
+      description: Adds asset.chat.type values used by chat transaction filtering.
+      payload:
+        $ref: '#/components/schemas/ClientWebSocketChatTypeSubscription'
+    balances:
+      description: Adds public account fields emitted by balances/change.
+      payload:
+        $ref: '#/components/schemas/ClientWebSocketBalanceSubscription'
+    blocks:
+      description: Enables or disables newBlock events for the socket.
+      payload:
+        $ref: '#/components/schemas/ClientWebSocketBlockSubscription'
+  serverEvents:
+    newTrans:
+      description: A transaction applied to the node's unconfirmed pool.
+      payload:
+        $ref: '#/components/schemas/ClientWebSocketNewTransaction'
+    balances/change:
+      description: Current requested balance fields after an account balance mutation.
+      payload:
+        $ref: '#/components/schemas/ClientWebSocketBalanceChange'
+    newBlock:
+      description: Compact header of a successfully applied and saved block.
+      payload:
+        $ref: '#/components/schemas/ClientWebSocketNewBlock'
+
 components:
   schemas:
+    # Client WebSocket
+    ClientWebSocketAddressSubscription:
+      $ref: 'websocket/AddressSubscription.yaml'
+    ClientWebSocketTransactionTypeSubscription:
+      $ref: 'websocket/TransactionTypeSubscription.yaml'
+    ClientWebSocketChatTypeSubscription:
+      $ref: 'websocket/ChatTypeSubscription.yaml'
+    ClientWebSocketBalanceSubscription:
+      $ref: 'websocket/BalanceSubscription.yaml'
+    ClientWebSocketBlockSubscription:
+      $ref: 'websocket/BlockSubscription.yaml'
+    ClientWebSocketNewTransaction:
+      $ref: 'common/transactions/AnyTransaction.yaml'
+    ClientWebSocketBalanceChange:
+      $ref: 'websocket/BalanceChangeEvent.yaml'
+    ClientWebSocketNewBlock:
+      $ref: 'websocket/NewBlockEvent.yaml'
+
     # Account
     GetAccountInfoResponseDto:
       $ref: 'accounts/GetAccountInfo/GetAccountInfoResponseDto.yaml'

--- a/specification/websocket/AddressSubscription.yaml
+++ b/specification/websocket/AddressSubscription.yaml
@@ -1,0 +1,12 @@
+description: >-
+  One ADAMANT address or a list of addresses. Values are validated and normalized to uppercase.
+oneOf:
+  - $ref: '../common/properties/AdamantAddress.yaml'
+  - type: array
+    minItems: 1
+    uniqueItems: true
+    items:
+      $ref: '../common/properties/AdamantAddress.yaml'
+example:
+  - U1234567890123456
+  - U6543210987654321

--- a/specification/websocket/AddressSubscription.yaml
+++ b/specification/websocket/AddressSubscription.yaml
@@ -1,5 +1,6 @@
 description: >-
-  One ADAMANT address or a list of addresses. Values are validated and normalized to uppercase.
+  One ADAMANT address or a list of addresses. The node validates values at runtime and stores
+  accepted addresses in uppercase; this schema does not perform that validation or normalization.
 oneOf:
   - $ref: '../common/properties/AdamantAddress.yaml'
   - type: array

--- a/specification/websocket/BalanceChangeEvent.yaml
+++ b/specification/websocket/BalanceChangeEvent.yaml
@@ -1,0 +1,28 @@
+type: object
+description: >-
+  Current values for the subscribed public balance fields that changed. No initial snapshot is
+  emitted. Values are decimal strings in 1/10^8 ADM units.
+required:
+  - address
+minProperties: 2
+additionalProperties: false
+properties:
+  address:
+    $ref: '../common/properties/AdamantAddress.yaml'
+  balance:
+    type: string
+    pattern: '^[0-9]+$'
+    description: Confirmed account balance.
+  unconfirmedBalance:
+    type: string
+    pattern: '^[0-9]+$'
+    description: Account balance after applying the node's current unconfirmed pool.
+anyOf:
+  - required:
+      - balance
+  - required:
+      - unconfirmedBalance
+example:
+  address: U1234567890123456
+  balance: '100000000'
+  unconfirmedBalance: '99900000'

--- a/specification/websocket/BalanceSubscription.yaml
+++ b/specification/websocket/BalanceSubscription.yaml
@@ -1,0 +1,19 @@
+description: >-
+  One public balance field or a list of fields to add to the socket subscription. At least one
+  address subscription is required before balance changes can be delivered.
+oneOf:
+  - type: string
+    enum:
+      - balance
+      - unconfirmedBalance
+  - type: array
+    minItems: 1
+    uniqueItems: true
+    items:
+      type: string
+      enum:
+        - balance
+        - unconfirmedBalance
+example:
+  - balance
+  - unconfirmedBalance

--- a/specification/websocket/BlockSubscription.yaml
+++ b/specification/websocket/BlockSubscription.yaml
@@ -1,0 +1,3 @@
+type: boolean
+description: A scalar boolean that enables or disables newBlock events for the socket.
+example: true

--- a/specification/websocket/ChatTypeSubscription.yaml
+++ b/specification/websocket/ChatTypeSubscription.yaml
@@ -1,4 +1,7 @@
-description: One asset.chat.type value or a list of values to add to the socket subscription.
+description: >-
+  One asset.chat.type value or a list of values to add to the socket subscription. This WebSocket
+  contract follows the node's complete chat transaction type range (0-3), independently of REST
+  chat endpoints that expose narrower query filters.
 oneOf:
   - type: integer
     minimum: 0

--- a/specification/websocket/ChatTypeSubscription.yaml
+++ b/specification/websocket/ChatTypeSubscription.yaml
@@ -1,0 +1,16 @@
+description: One asset.chat.type value or a list of values to add to the socket subscription.
+oneOf:
+  - type: integer
+    minimum: 0
+    maximum: 3
+  - type: array
+    minItems: 1
+    uniqueItems: true
+    items:
+      type: integer
+      minimum: 0
+      maximum: 3
+example:
+  - 1
+  - 2
+  - 3

--- a/specification/websocket/NewBlockEvent.yaml
+++ b/specification/websocket/NewBlockEvent.yaml
@@ -1,0 +1,56 @@
+type: object
+description: >-
+  Compact header of a successfully applied and saved block. Historical database replay does not
+  produce this event.
+required:
+  - id
+  - height
+  - timestamp
+  - generatorPublicKey
+  - numberOfTransactions
+  - totalAmount
+  - totalFee
+  - reward
+additionalProperties: false
+properties:
+  id:
+    type: string
+    minLength: 1
+    maxLength: 20
+    pattern: '^[0-9]+$'
+  height:
+    type: integer
+    minimum: 1
+  timestamp:
+    type: integer
+    minimum: 0
+    description: Seconds since the ADAMANT epoch.
+  generatorPublicKey:
+    $ref: '../common/properties/PublicKey.yaml'
+  numberOfTransactions:
+    type: integer
+    minimum: 0
+  totalAmount:
+    type: integer
+    format: int64
+    minimum: 0
+    description: Total transferred amount in 1/10^8 ADM units.
+  totalFee:
+    type: integer
+    format: int64
+    minimum: 0
+    description: Total transaction fee in 1/10^8 ADM units.
+  reward:
+    type: integer
+    format: int64
+    minimum: 0
+    description: Forging reward in 1/10^8 ADM units.
+example:
+  id: '1739739671268673627'
+  height: 53532078
+  timestamp: 278966175
+  generatorPublicKey: 24636735d64711f91f7680bb348662bc74f7b3446e66702369527e3882dd30d6
+  numberOfTransactions: 2
+  totalAmount: 10000000
+  totalFee: 100000
+  reward: 10000000

--- a/specification/websocket/TransactionTypeSubscription.yaml
+++ b/specification/websocket/TransactionTypeSubscription.yaml
@@ -1,0 +1,15 @@
+description: One transaction type or a list of transaction types to add to the socket subscription.
+oneOf:
+  - type: integer
+    minimum: 0
+    maximum: 9
+  - type: array
+    minItems: 1
+    uniqueItems: true
+    items:
+      type: integer
+      minimum: 0
+      maximum: 9
+example:
+  - 0
+  - 8


### PR DESCRIPTION
## Description

Define reusable schemas for the client Socket.IO subscription inputs and server event payloads introduced for new blocks and account-balance changes. A top-level `x-client-websocket` extension maps public event names to their payload contracts without changing REST paths.

## Related issue

Closes #47

Related to Adamant-im/adamant#217
Related to Adamant-im/adamant#256

## Changes

- describe `address`, `types`, `assetChatTypes`, `balances`, and `blocks` subscription payloads
- define `balances/change` and compact `newBlock` event payload schemas
- reuse the existing transaction union for `newTrans`
- expose the event map through `x-client-websocket`
- document the extension in the repository README

## Impact

Adds reusable WebSocket contracts only. REST paths and response schemas are unchanged. The extension is informational for tooling that does not consume custom OpenAPI fields.

## How to test

- `npm run bundle`
- `npx prettier --check README.md specification/openapi.yaml specification/websocket/*.yaml`
- start Swagger UI locally and inspect the new component schemas

## Checklist

- [x] Repository artifacts are in English
- [x] Node issue links are explicit
- [x] Bundle and formatting checks completed successfully
- [x] The rendered schemas were reviewed locally
